### PR TITLE
ci: use private cgroup setting

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
       - /run
       - /run/lock
       - /tmp
-    cgroup: host
+    cgroup: private
     volumes:
       - /sys/fs/cgroup/freeipa.scope:/sys/fs/cgroup:rw
       - /lib/modules:/lib/modules:ro


### PR DESCRIPTION
Minor improvement to use private cgroup namespace.